### PR TITLE
Cleaning and perf [non breaking]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "svc16"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svc16"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Jan Neuendorf"]
 description = "An emulator for a simple virtual computer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ thiserror = "2.0.3"
 [features]
 default=[]
 gamepad = ["gilrs"]
+
+[profile.release]
+opt-level = 3
+codegen-units = 1
+lto = true

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -50,17 +50,10 @@ impl Engine {
         //The iterator can be shorter, in which case the rest of the memory is left as zeros.
         //If it is longer, the end is never read.
     {
-        let mut iter = state.into_iter();
+        let iter = state.into_iter();
         let mut memory = vec![0; MEMSIZE];
-        for i in 0..MEMSIZE {
-            match iter.next() {
-                Some(val) => {
-                    memory[i] = val;
-                }
-                _ => {
-                    break;
-                }
-            }
+        for (cell, val) in memory.iter_mut().zip(iter) {
+            *cell = val;
         }
         Self {
             memory,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -73,7 +73,7 @@ impl Engine {
         }
     }
     pub fn wants_to_sync(&self) -> bool {
-        return self.sync_called;
+        self.sync_called
     }
     pub fn set_input(&mut self, pos_code: u16, key_code: u16) {
         self.set(self.pos_code_dest, pos_code);
@@ -100,16 +100,16 @@ impl Engine {
 impl Engine {
     // Public for debugging.
     pub fn get(&self, index: u16) -> u16 {
-        return self.memory[index as usize];
+        self.memory[index as usize]
     }
     fn set(&mut self, index: u16, value: u16) {
         self.memory[index as usize] = value;
     }
     fn get_screen_buffer(&self, index: u16) -> u16 {
-        return self.screen_buffer[index as usize];
+        self.screen_buffer[index as usize]
     }
     fn get_utility_buffer(&self, index: u16) -> u16 {
-        return self.utility_buffer[index as usize];
+        self.utility_buffer[index as usize]
     }
     fn set_screen_buffer(&mut self, index: u16, value: u16) {
         self.screen_buffer[index as usize] = value;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -118,7 +118,13 @@ impl Engine {
         self.utility_buffer[index as usize] = value;
     }
     pub fn read_instruction(&self) -> [u16; 4] {
-        return [0, 1, 2, 3].map(|o| self.get(self.instruction_pointer.wrapping_add(o)));
+        let inst_ptr = self.instruction_pointer;
+        [
+            self.get(inst_ptr.wrapping_add(0)),
+            self.get(inst_ptr.wrapping_add(1)),
+            self.get(inst_ptr.wrapping_add(2)),
+            self.get(inst_ptr.wrapping_add(3)),
+        ]
     }
     fn advance_inst_ptr(&mut self) {
         self.instruction_pointer = self.instruction_pointer.wrapping_add(4);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -58,13 +58,13 @@ impl Engine {
         Self {
             memory: memory
                 .try_into()
-                .expect("failed to convert memory into boxed slice"),
+                .expect("failed to convert memory into boxed array"),
             screen_buffer: vec![0; MEMSIZE]
                 .try_into()
-                .expect("failed to convert screen buffer into boxed"),
+                .expect("failed to convert screen buffer into boxed array"),
             utility_buffer: vec![0; MEMSIZE]
                 .try_into()
-                .expect("failed to convert screen buffer into boxed"),
+                .expect("failed to convert screen buffer into boxed array"),
             instruction_pointer: 0,
             pos_code_dest: 0,
             key_code_dest: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
     }
 
     // This is not the screen-buffer itself. It still needs to be synchronized.
-    let mut raw_buffer = vec![0 as u16; 256 * 256];
+    let mut raw_buffer = vec![0u16; 256 * 256];
     let mut engine = Engine::new(read_u16s_from_file(&cli.program)?);
     let mut paused = false;
     let mut ipf = 0;
@@ -153,11 +153,9 @@ async fn main() -> Result<()> {
         let elapsed = start_time.elapsed();
         if elapsed < FRAMETIME {
             std::thread::sleep(FRAMETIME - elapsed);
-        } else {
-            if cli.verbose {
-                // If you see this, the program is running too slow on your PC.
-                println!("Frame was not processed in time");
-            }
+        } else if cli.verbose {
+            // If you see this, the program is running too slow on your PC.
+            println!("Frame was not processed in time");
         }
         next_frame().await;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn window_conf() -> Conf {
     // Both the scaling and the fullscreen options are only important for the initial launch of the window.
     // You can still rescale or exit fullscreen mode.
     let cli = Cli::parse();
-    if cli.fullscreen {}
+    
 
     Conf {
         window_title: "SVC16".to_owned(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,8 +17,8 @@ impl Layout {
             false => ((minsize / 256.).floor() * 256.).max(256.),
             true => minsize.max(256.),
         };
-        let x = (0. as f32).max((width - image_size) / 2.);
-        let y = (0. as f32).max((height - image_size) / 2.);
+        let x = (0f32).max((width - image_size) / 2.);
+        let y = (0f32).max((height - image_size) / 2.);
         let font_y = y + image_size / 15.;
         Self {
             x,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,7 +40,7 @@ fn rgb565_to_argb(rgb565: u16) -> (u8, u8, u8) {
     (r, g, b)
 }
 
-pub fn update_image_buffer(imbuff: &mut Vec<Color>, screen: &Vec<u16>) {
+pub fn update_image_buffer(imbuff: &mut [Color], screen: &[u16]) {
     for i in 0..RES * RES {
         let col = rgb565_to_argb(screen[i]);
         imbuff[i] = Color {


### PR DESCRIPTION
A few minor improvements and changes. I believe each change is explained in detail within each commit message but it mostly breaks into 4 parts:

1. fixing basic clippy lints (simplifying, collapsing, etc.)
2. performance improvements, I found an unlikely performance bottleneck inside of ``read_instruction`` by profiling using flamegraph. I still don't understand why the compiler wasn't optimizing this away. :shrug:  Either way it seems to now. There was also a couple of clones that I was able to remove, reducing dynamic allocation.
3. re-adding arrays, but this time as heap allocated, so they won't cause any stack-related issues. This *probably* will have no major effect either way, but *could* under specific circumstances allow slightly lighter code gen.
4. removing explicit returns where not required. This is more of a styling thing, as such I left it as a separate commit that can be safely removed.

All of these changes should be non-breaking.